### PR TITLE
Addition of proxy servers and session reuse

### DIFF
--- a/meraki.py
+++ b/meraki.py
@@ -978,7 +978,7 @@ def __returnhandler(statuscode, returntext, objtype, suppressprint):
 
 # List the dashboard administrators in this organization
 # https://dashboard.meraki.com/api_docs#list-the-dashboard-administrators-in-this-organization
-def getorgadmins(apikey, orgid, suppressprint=False, proxies=None, session=None):
+def getorgadmins(apikey, orgid, suppressprint=False, proxies=None, session=None, verify_access=True):
     """
 
     Args:
@@ -989,7 +989,8 @@ def getorgadmins(apikey, orgid, suppressprint=False, proxies=None, session=None)
     Returns:
 
     """
-    __hasorgaccess(apikey, orgid)
+    if verify_access:
+        __hasorgaccess(apikey, orgid)
     calltype = 'Organization'
 
     geturl = '{0}/organizations/{1}/admins'.format(str(base_url), str(orgid))
@@ -1011,11 +1012,12 @@ def getorgadmins(apikey, orgid, suppressprint=False, proxies=None, session=None)
 # Create a new dashboard administrator
 # https://dashboard.meraki.com/api_docs#create-a-new-dashboard-administrator
 def addadmin(apikey, orgid, email, name, orgaccess=None, tags=None, tagaccess=None, networks=None,
-             netaccess=None, suppressprint=False):
+             netaccess=None, suppressprint=False, proxies=None, session=None, verify_access=True):
     #
     # Confirm API Key has Admin Access Otherwise Raise Error
     #
-    __hasorgaccess(apikey, orgid)
+    if verify_access:
+        __hasorgaccess(apikey, orgid)
     calltype = 'Administrator'
 
     posturl = '{0}/organizations/{1}/admins'.format(str(base_url), str(orgid))
@@ -1109,7 +1111,10 @@ def addadmin(apikey, orgid, email, name, orgaccess=None, tags=None, tagaccess=No
             'tags': posttags,
             'networks': postnets
         }
-    dashboard = requests.post(posturl, data=json.dumps(postdata), headers=headers)
+    if session:
+        dashboard = session.post(posturl, data=json.dumps(postdata), headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.post(posturl, data=json.dumps(postdata), headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -1120,11 +1125,13 @@ def addadmin(apikey, orgid, email, name, orgaccess=None, tags=None, tagaccess=No
 # Update an administrator
 # https://dashboard.meraki.com/api_docs#update-an-administrator
 def updateadmin(apikey, orgid, adminid, email, name=None, orgaccess=None, tags=None, tagaccess=None,
-                networks=None, netaccess=None, suppressprint=False):
+                networks=None, netaccess=None, suppressprint=False, proxies=None, session=None,
+                verify_access=True):
     #
     # Confirm API Key has Admin Access Otherwise Raise Error
     #
-    __hasorgaccess(apikey, orgid)
+    if verify_access:
+        __hasorgaccess(apikey, orgid)
     calltype = 'Administrator'
 
     puturl = '{0}/organizations/{1}/admins/{2}'.format(str(base_url), str(orgid), str(adminid))
@@ -1245,7 +1252,10 @@ def updateadmin(apikey, orgid, adminid, email, name=None, orgaccess=None, tags=N
                 'networks': putnets
                 }
 
-    dashboard = requests.put(puturl, data=json.dumps(putdata), headers=headers)
+    if session:
+        dashboard = session.put(puturl, data=json.dumps(putdata), headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.put(puturl, data=json.dumps(putdata), headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -1255,11 +1265,12 @@ def updateadmin(apikey, orgid, adminid, email, name=None, orgaccess=None, tags=N
 
 # Revoke all access for a dashboard administrator within this organization
 # https://dashboard.meraki.com/api_docs#revoke-all-access-for-a-dashboard-administrator-within-this-organization
-def deladmin(apikey, orgid, adminid, suppressprint=False):
+def deladmin(apikey, orgid, adminid, suppressprint=False, proxies=None, session=None, verify_access=True):
     #
     # Confirm API Key has Admin Access Otherwise Raise Error
     #
-    __hasorgaccess(apikey, orgid)
+    if verify_access:
+        __hasorgaccess(apikey, orgid)
     calltype = 'Administrator'
 
     delurl = '{0}/organizations/{1}/admins/{2}'.format(str(base_url), str(orgid), str(adminid))
@@ -1267,7 +1278,10 @@ def deladmin(apikey, orgid, adminid, suppressprint=False):
         'x-cisco-meraki-api-key': format(str(apikey)),
         'Content-Type': 'application/json'
     }
-    dashboard = requests.delete(delurl, headers=headers)
+    if session:
+        dashboard = session.delete(delurl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.delete(delurl, headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -1279,14 +1293,17 @@ def deladmin(apikey, orgid, adminid, suppressprint=False):
 
 # List the clients of a device, up to a maximum of a month ago. The usage of each client is returned in kilobytes. If the device is a switch, the switchport is returned; otherwise the switchport field is null.
 # https://dashboard.meraki.com/api_docs#list-the-clients-of-a-device-up-to-a-maximum-of-a-month-ago
-def getclients(apikey, serialnum, timestamp=86400, suppressprint=False):
+def getclients(apikey, serialnum, timestamp=86400, suppressprint=False, proxies=None, session=None):
     calltype = 'Device Clients'
     geturl = '{0}/devices/{1}/clients?timespan={2}'.format(str(base_url), str(serialnum), str(timestamp))
     headers = {
         'x-cisco-meraki-api-key': format(str(apikey)),
         'Content-Type': 'application/json'
     }
-    dashboard = requests.get(geturl, headers=headers)
+    if session:
+        dashboard = session.get(geturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.get(geturl, headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -1298,11 +1315,12 @@ def getclients(apikey, serialnum, timestamp=86400, suppressprint=False):
 
 # List the configuration templates for this organization
 # https://dashboard.meraki.com/api_docs#list-the-configuration-templates-for-this-organization
-def gettemplates(apikey, orgid, suppressprint=False):
+def gettemplates(apikey, orgid, suppressprint=False, proxies=None, session=None, verify_access=True):
     #
     # Confirm API Key has Admin Access Otherwise Raise Error
     #
-    __hasorgaccess(apikey, orgid)
+    if verify_access:
+        __hasorgaccess(apikey, orgid)
     calltype = 'Templates'
 
     geturl = '{0}/organizations/{1}/configTemplates'.format(str(base_url), str(orgid))
@@ -1310,7 +1328,10 @@ def gettemplates(apikey, orgid, suppressprint=False):
         'x-cisco-meraki-api-key': format(str(apikey)),
         'Content-Type': 'application/json'
     }
-    dashboard = requests.get(geturl, headers=headers)
+    if session:
+        dashboard = session.get(geturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.get(geturl, headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -1320,11 +1341,12 @@ def gettemplates(apikey, orgid, suppressprint=False):
 
 # Remove a configuration template
 # https://dashboard.meraki.com/api_docs#remove-a-configuration-template
-def deltemplate(apikey, orgid, templateid, suppressprint=False):
+def deltemplate(apikey, orgid, templateid, suppressprint=False, proxies=None, session=None, verify_access=True):
     #
     # Confirm API Key has Admin Access Otherwise Raise Error
     #
-    __hasorgaccess(apikey, orgid)
+    if verify_access:
+        __hasorgaccess(apikey, orgid)
     calltype = 'Template'
 
     delurl = '{0}/organizations/{1}/configTemplates/{2}'.format(str(base_url), str(orgid), str(templateid))
@@ -1332,7 +1354,11 @@ def deltemplate(apikey, orgid, templateid, suppressprint=False):
         'x-cisco-meraki-api-key': format(str(apikey)),
         'Content-Type': 'application/json'
     }
-    dashboard = requests.delete(delurl, headers=headers)
+    if session:
+        dashboard = session.delete(delurl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.delete(delurl, headers=headers, proxies=proxies)
+
     #
     # Call return handler function to parse Dashboard response
     #
@@ -1344,7 +1370,7 @@ def deltemplate(apikey, orgid, templateid, suppressprint=False):
 
 # List the devices in a network
 # https://dashboard.meraki.com/api_docs#list-the-devices-in-a-network
-def getnetworkdevices(apikey, networkid, suppressprint=False):
+def getnetworkdevices(apikey, networkid, suppressprint=False, proxies=None, session=None):
     """
 
     Args:
@@ -1361,7 +1387,10 @@ def getnetworkdevices(apikey, networkid, suppressprint=False):
         'x-cisco-meraki-api-key': format(str(apikey)),
         'Content-Type': 'application/json'
     }
-    dashboard = requests.get(geturl, headers=headers)
+    if session:
+        dashboard = session.get(geturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.get(geturl, headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -1371,7 +1400,7 @@ def getnetworkdevices(apikey, networkid, suppressprint=False):
 
 # Return a single device
 # https://dashboard.meraki.com/api_docs#return-a-single-device
-def getdevicedetail(apikey, networkid, serialnumber, suppressprint=False):
+def getdevicedetail(apikey, networkid, serialnumber, suppressprint=False, proxies=None, session=None):
     calltype = 'Device Detail'
     geturl = '{0}/networks/{1}/devices/{2}'.format(str(base_url), str(networkid), str(serialnumber))
     headers = {
@@ -1379,7 +1408,32 @@ def getdevicedetail(apikey, networkid, serialnumber, suppressprint=False):
         'Content-Type': 'application/json'
     }
 
-    dashboard = requests.get(geturl, headers=headers)
+    if session:
+        dashboard = session.get(geturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.get(geturl, headers=headers, proxies=proxies)
+    #
+    # Call return handler function to parse Dashboard response
+    #
+    result = __returnhandler(dashboard.status_code, dashboard.text, calltype, suppressprint)
+    return result
+
+
+# Return a device lldp information
+# https://dashboard.meraki.com/api_docs#list-lldp-and-cdp-information-for-a-device
+def getdevicelldp(apikey, networkid, serialnumber, timestamp=86400, suppressprint=False, proxies=None, session=None):
+    calltype = 'Device LLDP-CDP'
+    geturl = '{0}/networks/{1}/devices/{2}/lldp_cdp?timespan={3}'.format(str(base_url), str(networkid),
+                                                                         str(serialnumber), str(timestamp))
+    headers = {
+        'x-cisco-meraki-api-key': format(str(apikey)),
+        'Content-Type': 'application/json'
+    }
+
+    if session:
+        dashboard = session.get(geturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.get(geturl, headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -1389,7 +1443,7 @@ def getdevicedetail(apikey, networkid, serialnumber, suppressprint=False):
 
 # Return an array containing the uplink information for a device.
 # https://dashboard.meraki.com/api_docs#return-an-array-containing-the-uplink-information-for-a-device
-def getdeviceuplink(apikey, networkid, serialnumber, suppressprint=False):
+def getdeviceuplink(apikey, networkid, serialnumber, suppressprint=False, proxies=None, session=None):
     calltype = 'Device Uplink'
     geturl = '{0}/networks/{1}/devices/{2}/uplink'.format(str(base_url), str(networkid), str(serialnumber))
     headers = {
@@ -1397,7 +1451,10 @@ def getdeviceuplink(apikey, networkid, serialnumber, suppressprint=False):
         'Content-Type': 'application/json'
     }
 
-    dashboard = requests.get(geturl, headers=headers)
+    if session:
+        dashboard = session.get(geturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.get(geturl, headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -1407,7 +1464,8 @@ def getdeviceuplink(apikey, networkid, serialnumber, suppressprint=False):
 
 # Update the attributes of a device
 # https://dashboard.meraki.com/api_docs#update-the-attributes-of-a-device
-def updatedevice(apikey, networkid, serial, name=None, tags=None, lat=None, lng=None, address=None, move=None, suppressprint=False):
+def updatedevice(apikey, networkid, serial, name=None, tags=None, lat=None, lng=None, address=None, move=None,
+                 suppressprint=False, proxies=None, session=None):
     # move needs to be str 'true' or 'false' to work; boolean True and False do not
     calltype = 'Device'
     posturl = '{0}/networks/{1}/devices/{2}'.format(str(base_url), str(networkid), str(serial))
@@ -1438,7 +1496,10 @@ def updatedevice(apikey, networkid, serial, name=None, tags=None, lat=None, lng=
     if move:
         putdata['moveMapMarker'] = move
 
-    dashboard = requests.put(posturl, data=json.dumps(putdata), headers=headers)
+    if session:
+        dashboard = session.put(posturl, data=json.dumps(putdata), headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.put(posturl, data=json.dumps(putdata), headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -1448,7 +1509,7 @@ def updatedevice(apikey, networkid, serial, name=None, tags=None, lat=None, lng=
 
 # Claim a device into a network
 # https://dashboard.meraki.com/api_docs#claim-a-device-into-a-network
-def adddevtonet(apikey, networkid, serial, suppressprint=False):
+def adddevtonet(apikey, networkid, serial, suppressprint=False, proxies=None, session=None):
     calltype = 'Device'
     posturl = '{0}/networks/{1}/devices/claim'.format(str(base_url), str(networkid))
     headers = {
@@ -1458,7 +1519,11 @@ def adddevtonet(apikey, networkid, serial, suppressprint=False):
     postdata = {
         'serial': format(str(serial))
     }
-    dashboard = requests.post(posturl, data=json.dumps(postdata), headers=headers)
+
+    if session:
+        dashboard = session.post(posturl, data=json.dumps(postdata), headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.post(posturl, data=json.dumps(postdata), headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -1468,14 +1533,18 @@ def adddevtonet(apikey, networkid, serial, suppressprint=False):
 
 # Remove a single device
 # https://dashboard.meraki.com/api_docs#remove-a-single-device
-def removedevfromnet(apikey, networkid, serial, suppressprint=False):
+def removedevfromnet(apikey, networkid, serial, suppressprint=False, proxies=None, session=None):
     calltype = 'Device'
     posturl = '{0}/networks/{1}/devices/{2}/remove'.format(str(base_url), str(networkid), str(serial))
     headers = {
         'x-cisco-meraki-api-key': format(str(apikey)),
         'Content-Type': 'application/json'
     }
-    dashboard = requests.post(posturl, headers=headers)
+
+    if session:
+        dashboard = session.post(posturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.post(posturl, headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -1487,21 +1556,26 @@ def removedevfromnet(apikey, networkid, serial, suppressprint=False):
 
 # Return the L3 firewall rules for an SSID on an MR network
 # https://dashboard.meraki.com/api_docs#return-the-l3-firewall-rules-for-an-ssid-on-an-mr-network
-def getssidl3fwrules(apikey, networkid, ssidnum, suppressprint=False):
+def getssidl3fwrules(apikey, networkid, ssidnum, suppressprint=False, proxies=None, session=None):
     calltype = 'Wireless L3 Firewall'
     geturl = '{0}/networks/{1}/ssids/{2}/l3FirewallRules'.format(str(base_url), str(networkid), str(ssidnum))
     headers = {
         'x-cisco-meraki-api-key': format(str(apikey)),
         'Content-Type': 'application/json'
     }
-    dashboard = requests.get(geturl, headers=headers)
+
+    if session:
+        dashboard = session.get(geturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.get(geturl, headers=headers, proxies=proxies)
     result = __returnhandler(dashboard.status_code, dashboard.text, calltype, suppressprint)
     return result
 
 
 # Update the L3 firewall rules of an SSID on an MR network
 # https://dashboard.meraki.com/api_docs#update-the-l3-firewall-rules-of-an-ssid-on-an-mr-network
-def updatessidl3fwrules(apikey, networkid, ssidnum, fwrules, allowlan=None, suppressprint=False):
+def updatessidl3fwrules(apikey, networkid, ssidnum, fwrules, allowlan=None, suppressprint=False,
+                        proxies=None, session=None):
     # fwrules = [{'comment': 'A note about the rule', 'policy': 'deny', 'protocol': 'tcp', 'destPort': 'Any', 'destCidr': '192.168.1.0/24'}]
 
     calltype = 'Wireless L3 Firewall'
@@ -1521,7 +1595,10 @@ def updatessidl3fwrules(apikey, networkid, ssidnum, fwrules, allowlan=None, supp
     else:
         putdata['allowLanAccess'] = allowlan
 
-    dashboard = requests.put(puturl, data=json.dumps(putdata), headers=headers)
+    if session:
+        dashboard = session.put(puturl, data=json.dumps(putdata), headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.put(puturl, data=json.dumps(putdata), headers=headers, proxies=proxies)
     result = __returnhandler(dashboard.status_code, dashboard.text, calltype, suppressprint)
     return result
 
@@ -1530,11 +1607,13 @@ def updatessidl3fwrules(apikey, networkid, ssidnum, fwrules, allowlan=None, supp
 
 # List the networks in an organization
 # https://dashboard.meraki.com/api_docs#list-the-networks-in-an-organization
-def getnetworklist(apikey, orgid, templateid=None, suppressprint=False):
+def getnetworklist(apikey, orgid, templateid=None, suppressprint=False, proxies=None, session=None,
+                   verify_access=True):
     #
     # Confirm API Key has Admin Access Otherwise Raise Error
     #
-    __hasorgaccess(apikey, orgid)
+    if verify_access:
+        __hasorgaccess(apikey, orgid)
     calltype = 'Network'
 
     geturl = '{0}/organizations/{1}/networks'.format(str(base_url), str(orgid))
@@ -1544,7 +1623,11 @@ def getnetworklist(apikey, orgid, templateid=None, suppressprint=False):
         'x-cisco-meraki-api-key': format(str(apikey)),
         'Content-Type': 'application/json'
     }
-    dashboard = requests.get(geturl, headers=headers)
+
+    if session:
+        dashboard = session.get(geturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.get(geturl, headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -1554,14 +1637,18 @@ def getnetworklist(apikey, orgid, templateid=None, suppressprint=False):
 
 # Return a network
 # https://dashboard.meraki.com/api_docs#return-a-network
-def getnetworkdetail(apikey, networkid, suppressprint=False):
+def getnetworkdetail(apikey, networkid, suppressprint=False, proxies=None, session=None):
     calltype = 'Network Detail'
     geturl = '{0}/networks/{1}'.format(str(base_url), str(networkid))
     headers = {
         'x-cisco-meraki-api-key': format(str(apikey)),
         'Content-Type': 'application/json'
     }
-    dashboard = requests.get(geturl, headers=headers)
+
+    if session:
+        dashboard = session.get(geturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.get(geturl, headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -1571,7 +1658,7 @@ def getnetworkdetail(apikey, networkid, suppressprint=False):
 
 # Update a network
 # https://dashboard.meraki.com/api_docs#update-a-network
-def updatenetwork(apikey, networkid, name, tz, tags, suppressprint=False):
+def updatenetwork(apikey, networkid, name=None, tz=None, tags=None, suppressprint=False, proxies=None, session=None):
 
     calltype = 'Network'
     puturl = '{0}/networks/{1}'.format(str(base_url), str(networkid))
@@ -1592,7 +1679,10 @@ def updatenetwork(apikey, networkid, name, tz, tags, suppressprint=False):
     if tags:
         putdata['tags'] = __listtotag(tags)
 
-    dashboard = requests.put(puturl, data=json.dumps(putdata), headers=headers)
+    if session:
+        dashboard = session.put(puturl, data=json.dumps(putdata), headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.put(puturl, data=json.dumps(putdata), headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -1602,14 +1692,16 @@ def updatenetwork(apikey, networkid, name, tz, tags, suppressprint=False):
 
 # Create a network
 # https://dashboard.meraki.com/api_docs#create-a-network
-def addnetwork(apikey, orgid, name, nettype, tags, tz, suppressprint=False):
+def addnetwork(apikey, orgid, name, nettype, tags, tz, suppressprint=False, proxies=None, session=None,
+               verify_access=True):
     """
     Action:     Adds new network to Meraki Dashboard with passed parameters
     Call to:    https://dashboard.meraki.com/api/v0
     Input: User API Key, Target Organization, New Network Parameters
     Otput: JSON string returned from Dashboard API Call
     """
-    __hasorgaccess(apikey, orgid)
+    if verify_access:
+        __hasorgaccess(apikey, orgid)
     calltype = 'Network'
 
     posturl = '{0}/organizations/{1}/networks'.format(str(base_url), str(orgid))
@@ -1626,21 +1718,29 @@ def addnetwork(apikey, orgid, name, nettype, tags, tz, suppressprint=False):
         'timeZone': format(str(tz))
     }
     postdata = json.dumps(postdata)
-    dashboard = requests.post(posturl, data=postdata, headers=headers)
+
+    if session:
+        dashboard = session.post(posturl, data=postdata, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.post(posturl, data=postdata, headers=headers, proxies=proxies)
     result = __returnhandler(dashboard.status_code, dashboard.text, calltype, suppressprint)
     return result
 
 
 # Delete a network
 # https://dashboard.meraki.com/api_docs#delete-a-network
-def delnetwork(apikey, networkid, suppressprint=False):
+def delnetwork(apikey, networkid, suppressprint=False, proxies=None, session=None):
     calltype = 'Network'
     delurl = '{0}/networks/{1}'.format(str(base_url), str(networkid))
     headers = {
         'x-cisco-meraki-api-key': format(str(apikey)),
         'Content-Type': 'application/json'
     }
-    dashboard = requests.delete(delurl, headers=headers)
+
+    if session:
+        dashboard = session.delete(delurl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.delete(delurl, headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -1650,7 +1750,7 @@ def delnetwork(apikey, networkid, suppressprint=False):
 
 # Bind a network to a template.
 # https://dashboard.meraki.com/api_docs#bind-a-network-to-a-template
-def bindtotemplate(apikey, networkid, templateid, autobind=False, suppressprint=False):
+def bindtotemplate(apikey, networkid, templateid, autobind=False, suppressprint=False, proxies=None, session=None):
     calltype = 'Template Bind'
     posturl = '{0}/networks/{1}/bind'.format(str(base_url), str(networkid))
     postdata={}
@@ -1663,7 +1763,10 @@ def bindtotemplate(apikey, networkid, templateid, autobind=False, suppressprint=
     if autobind:
         postdata['autoBind'] = autobind
 
-    dashboard = requests.post(posturl, data=json.dumps(postdata), headers=headers)
+    if session:
+        dashboard = session.post(posturl, data=json.dumps(postdata), headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.post(posturl, data=json.dumps(postdata), headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -1673,14 +1776,18 @@ def bindtotemplate(apikey, networkid, templateid, autobind=False, suppressprint=
 
 # Unbind a network from a template.
 # https://dashboard.meraki.com/api_docs#unbind-a-network-from-a-template
-def unbindfromtemplate(apikey, networkid, suppressprint=False):
+def unbindfromtemplate(apikey, networkid, suppressprint=False, proxies=None, session=None):
     calltype = 'Network Unbind'
     posturl = '{0}/networks/{1}/unbind'.format(str(base_url), str(networkid))
     headers = {
         'x-cisco-meraki-api-key': format(str(apikey)),
         'Content-Type': 'application/json'
     }
-    dashboard = requests.post(posturl, headers=headers)
+
+    if session:
+        dashboard = session.post(posturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.post(posturl, headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -1690,14 +1797,18 @@ def unbindfromtemplate(apikey, networkid, suppressprint=False):
 
 # Return the site-to-site VPN settings of a network. Only valid for MX networks.
 # https://dashboard.meraki.com/api_docs#return-the-site-to-site-vpn-settings-of-a-network
-def getvpnsettings(apikey, networkid, suppressprint=False):
+def getvpnsettings(apikey, networkid, suppressprint=False, proxies=None, session=None):
     calltype = 'AutoVPN'
     geturl = '{0}/networks/{1}/siteToSiteVpn'.format(str(base_url), str(networkid))
     headers = {
         'x-cisco-meraki-api-key': format(str(apikey)),
         'Content-Type': 'application/json'
     }
-    dashboard = requests.get(geturl, headers=headers)
+
+    if session:
+        dashboard = session.get(geturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.get(geturl, headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -1708,7 +1819,7 @@ def getvpnsettings(apikey, networkid, suppressprint=False):
 # Update the site-to-site VPN settings of a network. Only valid for MX networks in NAT mode.
 # https://dashboard.meraki.com/api_docs#update-the-site-to-site-vpn-settings-of-a-network
 def updatevpnsettings(apikey, networkid, mode='none', subnets=None, usevpn=None, hubnetworks=None, defaultroute=None,
-                      suppressprint=False):
+                      suppressprint=False, proxies=None, session=None):
     calltype = 'AutoVPN'
     puturl = '{0}/networks/{1}/siteToSiteVpn'.format(str(base_url), str(networkid))
     headers = {
@@ -1737,7 +1848,11 @@ def updatevpnsettings(apikey, networkid, mode='none', subnets=None, usevpn=None,
     print(putdata)
 
     putdata = json.dumps(putdata)
-    dashboard = requests.put(puturl, data=putdata, headers=headers)
+
+    if session:
+        dashboard = session.put(puturl, data=putdata, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.put(puturl, data=putdata, headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -1747,7 +1862,8 @@ def updatevpnsettings(apikey, networkid, mode='none', subnets=None, usevpn=None,
 
 # The traffic analysis data for this network. Traffic Analysis with Hostname Visibility must be enabled on the network.
 # https://dashboard.meraki.com/api_docs#the-traffic-analysis-data-for-this-network
-def getnetworktrafficstats(apikey, networkid, timespan=86400, devicetype='combined', suppressprint=False):
+def getnetworktrafficstats(apikey, networkid, timespan=86400, devicetype='combined', suppressprint=False,
+                           proxies=None, session=None):
     calltype = 'Network Detail'
     geturl = '{0}/networks/{1}/traffic?timespan={2}&deviceType={3}'.format(str(base_url), str(networkid), str(timespan),
                                                                            str(devicetype))
@@ -1755,7 +1871,11 @@ def getnetworktrafficstats(apikey, networkid, timespan=86400, devicetype='combin
         'x-cisco-meraki-api-key': format(str(apikey)),
         'Content-Type': 'application/json'
     }
-    dashboard = requests.get(geturl, headers=headers)
+
+    if session:
+        dashboard = session.get(geturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.get(geturl, headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -1765,21 +1885,25 @@ def getnetworktrafficstats(apikey, networkid, timespan=86400, devicetype='combin
 
 # List the access policies for this network. Only valid for MS networks.
 # https://dashboard.meraki.com/api_docs#list-the-access-policies-for-this-network
-def getaccesspolicies(apikey, networkid, suppressprint=False):
+def getaccesspolicies(apikey, networkid, suppressprint=False, proxies=None, session=None):
     calltype = 'Network Detail'
     geturl = '{0}/networks/{1}/accessPolicies'.format(str(base_url), str(networkid))
     headers = {
         'x-cisco-meraki-api-key': format(str(apikey)),
         'Content-Type': 'application/json'
     }
-    dashboard = requests.get(geturl, headers=headers)
+
+    if session:
+        dashboard = session.get(geturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.get(geturl, headers=headers, proxies=proxies)
     result = __returnhandler(dashboard.status_code, dashboard.text, calltype, suppressprint)
     return result
 
 
 # List Air Marshal scan results from a network
 # https://dashboard.meraki.com/api_docs#list-air-marshal-scan-results-from-a-network
-def getairmarshal(apikey, networkid, timespan=3600, suppressprint=False):
+def getairmarshal(apikey, networkid, timespan=3600, suppressprint=False, proxies=None, session=None):
     # Parameter timespan for which results will be fetched. Must be at most one month in seconds.
     if timespan > 2592000:
         raise ValueError('Timespan must be at most one month in seconds.')
@@ -1790,7 +1914,11 @@ def getairmarshal(apikey, networkid, timespan=3600, suppressprint=False):
         'x-cisco-meraki-api-key': format(str(apikey)),
         'Content-Type': 'application/json'
     }
-    dashboard = requests.get(geturl, headers=headers)
+
+    if session:
+        dashboard = session.get(geturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.get(geturl, headers=headers, proxies=proxies)
     result = __returnhandler(dashboard.status_code, dashboard.text, calltype, suppressprint)
     return result
 
@@ -1799,7 +1927,7 @@ def getairmarshal(apikey, networkid, timespan=3600, suppressprint=False):
 
 # List the organizations that the user has privileges on
 # https://dashboard.meraki.com/api_docs#list-the-organizations-that-the-user-has-privileges-on
-def myorgaccess(apikey, suppressprint=False):
+def myorgaccess(apikey, suppressprint=False, proxies=None, session=None):
     """
 
     Args:
@@ -1815,7 +1943,11 @@ def myorgaccess(apikey, suppressprint=False):
         'X-Cisco-Meraki-API-Key': format(str(apikey)),
         'Content-Type': 'application/json'
     }
-    dashboard = requests.get(geturl, headers=headers)
+
+    if session:
+        dashboard = session.get(geturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.get(geturl, headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -1825,7 +1957,7 @@ def myorgaccess(apikey, suppressprint=False):
 
 # Return an organization
 # https://dashboard.meraki.com/api_docs#return-an-organization
-def getorg(apikey, orgid, suppressprint=False):
+def getorg(apikey, orgid, suppressprint=False, proxies=None, session=None):
     """
 
     Args:
@@ -1842,7 +1974,11 @@ def getorg(apikey, orgid, suppressprint=False):
         'x-cisco-meraki-api-key': format(str(apikey)),
         'Content-Type': 'application/json'
     }
-    dashboard = requests.get(geturl, headers=headers)
+
+    if session:
+        dashboard = session.get(geturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.get(geturl, headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -1852,7 +1988,7 @@ def getorg(apikey, orgid, suppressprint=False):
 
 # Update an organization
 # https://dashboard.meraki.com/api_docs#update-an-organization
-def renameorg(apikey, orgid, neworgname, suppressprint=False):
+def renameorg(apikey, orgid, neworgname, suppressprint=False, proxies=None, session=None, verify_access=True):
     __hasorgaccess(apikey, orgid)
     calltype = 'Organization Rename'
     puturl = '{0}/organizations/{1}'.format(str(base_url), str(orgid))
@@ -1863,7 +1999,11 @@ def renameorg(apikey, orgid, neworgname, suppressprint=False):
     putdata = {
         'name': format(str(neworgname))
     }
-    dashboard = requests.put(puturl, data=json.dumps(putdata), headers=headers)
+
+    if session:
+        dashboard = session.put(puturl, data=json.dumps(putdata), headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.put(puturl, data=json.dumps(putdata), headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -1873,7 +2013,7 @@ def renameorg(apikey, orgid, neworgname, suppressprint=False):
 
 # Create a new organization
 # https://dashboard.meraki.com/api_docs#create-a-new-organization
-def addorg(apikey, neworgname, suppressprint=False):
+def addorg(apikey, neworgname, suppressprint=False, proxies=None, session=None):
     calltype = 'Organization'
     posturl = '{0}/organizations/'.format(str(base_url))
     headers = {
@@ -1883,7 +2023,11 @@ def addorg(apikey, neworgname, suppressprint=False):
     postdata = {
         'name': format(str(neworgname))
     }
-    dashboard = requests.post(posturl, data=json.dumps(postdata), headers=headers)
+
+    if session:
+        dashboard = session.post(posturl, data=json.dumps(postdata), headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.post(posturl, data=json.dumps(postdata), headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -1893,8 +2037,9 @@ def addorg(apikey, neworgname, suppressprint=False):
 
 # Create a new organization by cloning the addressed organization
 # https://dashboard.meraki.com/api_docs#create-a-new-organization-by-cloning-the-addressed-organization
-def cloneorg(apikey, orgid, neworgname, suppressprint=False):
-    __hasorgaccess(apikey, orgid)
+def cloneorg(apikey, orgid, neworgname, suppressprint=False, proxies=None, session=None, verify_access=True):
+    if verify_access:
+        __hasorgaccess(apikey, orgid)
     calltype = 'Organization Clone'
     posturl = '{0}/organizations/{1}/clone'.format(str(base_url), str(orgid))
     headers = {
@@ -1904,7 +2049,11 @@ def cloneorg(apikey, orgid, neworgname, suppressprint=False):
     postdata = {
         'name': format(str(neworgname))
     }
-    dashboard = requests.post(posturl, data=json.dumps(postdata), headers=headers)
+
+    if session:
+        dashboard = session.post(posturl, data=json.dumps(postdata), headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.post(posturl, data=json.dumps(postdata), headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -1914,7 +2063,8 @@ def cloneorg(apikey, orgid, neworgname, suppressprint=False):
 
 # Claim a device, license key, or order into an organization. When claiming by order, all devices and licenses in the order will be claimed; licenses will be added to the organization and devices will be placed in the organization's inventory. These three types of claims are mutually exclusive and cannot be performed in one request.
 # https://dashboard.meraki.com/api_docs#claim-a-device-license-key-or-order-into-an-organization
-def claim(apikey, orgid, serial=None, licensekey=None, licensemode=None, orderid=None, suppressprint=False):
+def claim(apikey, orgid, serial=None, licensekey=None, licensemode=None, orderid=None, suppressprint=False,
+          proxies=None, session=None):
     calltype = 'Claim'
     posturl = '{0}/organizations/{1}/claim'.format(str(base_url), str(orgid))
     headers = {
@@ -1940,7 +2090,11 @@ def claim(apikey, orgid, serial=None, licensekey=None, licensemode=None, orderid
         postdata['licenseMode'] = serial
     elif orderid is not None:
         postdata['orderId'] = orderid
-    dashboard = requests.post(posturl, data=json.dumps(postdata), headers=headers)
+
+    if session:
+        dashboard = session.post(posturl, data=json.dumps(postdata), headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.post(posturl, data=json.dumps(postdata), headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -1950,11 +2104,12 @@ def claim(apikey, orgid, serial=None, licensekey=None, licensemode=None, orderid
 
 # Return the license state for an organization
 # https://dashboard.meraki.com/api_docs#return-the-license-state-for-an-organization
-def getlicensestate(apikey, orgid, suppressprint=False):
+def getlicensestate(apikey, orgid, suppressprint=False, proxies=None, session=None, verify_access=True):
     #
     # Confirm API Key has Admin Access Otherwise Raise Error
     #
-    __hasorgaccess(apikey, orgid)
+    if verify_access:
+        __hasorgaccess(apikey, orgid)
     calltype = 'License'
 
     geturl = '{0}/organizations/{1}/licenseState'.format(str(base_url), str(orgid))
@@ -1962,7 +2117,11 @@ def getlicensestate(apikey, orgid, suppressprint=False):
         'x-cisco-meraki-api-key': format(str(apikey)),
         'Content-Type': 'application/json'
     }
-    dashboard = requests.get(geturl, headers=headers)
+
+    if session:
+        dashboard = session.get(geturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.get(geturl, headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -1972,7 +2131,7 @@ def getlicensestate(apikey, orgid, suppressprint=False):
 
 # Return the inventory for an organization
 # https://dashboard.meraki.com/api_docs#return-the-inventory-for-an-organization
-def getorginventory(apikey, orgid, suppressprint=False):
+def getorginventory(apikey, orgid, suppressprint=False, proxies=None, session=None, verify_access=True):
     """
 
     Args:
@@ -1983,7 +2142,8 @@ def getorginventory(apikey, orgid, suppressprint=False):
     Returns: JSON formatted string of organization inventory
 
     """
-    __hasorgaccess(apikey, orgid)
+    if verify_access:
+        __hasorgaccess(apikey, orgid)
     calltype = 'Inventory'
 
     geturl = '{0}/organizations/{1}/inventory'.format(str(base_url), str(orgid))
@@ -1991,7 +2151,11 @@ def getorginventory(apikey, orgid, suppressprint=False):
         'x-cisco-meraki-api-key': format(str(apikey)),
         'Content-Type': 'application/json'
     }
-    dashboard = requests.get(geturl, headers=headers)
+
+    if session:
+        dashboard = session.get(geturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.get(geturl, headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -2001,11 +2165,12 @@ def getorginventory(apikey, orgid, suppressprint=False):
 
 # Return the SNMP settings for an organization
 # https://dashboard.meraki.com/api_docs#return-the-snmp-settings-for-an-organization
-def getsnmpsettings(apikey, orgid, suppressprint=False):
+def getsnmpsettings(apikey, orgid, suppressprint=False, proxies=None, session=None, verify_access=True):
     #
     # Confirm API Key has Admin Access Otherwise Raise Error
     #
-    __hasorgaccess(apikey, orgid)
+    if verify_access:
+        __hasorgaccess(apikey, orgid)
     calltype = 'SNMP Settings'
 
     geturl = '{0}/organizations/{1}/snmp'.format(str(base_url), str(orgid))
@@ -2013,7 +2178,11 @@ def getsnmpsettings(apikey, orgid, suppressprint=False):
         'x-cisco-meraki-api-key': format(str(apikey)),
         'Content-Type': 'application/json'
     }
-    dashboard = requests.get(geturl, headers=headers)
+
+    if session:
+        dashboard = session.get(geturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.get(geturl, headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -2024,11 +2193,13 @@ def getsnmpsettings(apikey, orgid, suppressprint=False):
 # Update the SNMP settings for an organization
 # https://dashboard.meraki.com/api_docs#update-the-snmp-settings-for-an-organization
 def updatesnmpsettings(apikey, orgid, v2c=False, v3=False, v3authmode='SHA', v3authpw=None, v3privmode='AES128',
-                       v3privpw=None, allowedips=None, suppressprint=False):
+                       v3privpw=None, allowedips=None, suppressprint=False, proxies=None, session=None,
+                       verify_access=True):
     #
     # Confirm API Key has Admin Access Otherwise Raise Error
     #
-    __hasorgaccess(apikey, orgid)
+    if verify_access:
+        __hasorgaccess(apikey, orgid)
     calltype = 'SNMP'
     puturl = '{0}/organizations/{1}/snmp'.format(str(base_url), str(orgid))
     headers = {
@@ -2071,7 +2242,11 @@ def updatesnmpsettings(apikey, orgid, v2c=False, v3=False, v3authmode='SHA', v3a
         putdata['peerIps'] = None
 
     putdata = json.dumps(putdata)
-    dashboard = requests.put(puturl, data=putdata, headers=headers)
+
+    if session:
+        dashboard = session.put(puturl, data=putdata, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.put(puturl, data=putdata, headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -2081,11 +2256,12 @@ def updatesnmpsettings(apikey, orgid, v2c=False, v3=False, v3authmode='SHA', v3a
 
 # Return the third party VPN peers for an organization
 # https://dashboard.meraki.com/api_docs#return-the-third-party-vpn-peers-for-an-organization
-def getnonmerakivpnpeers(apikey, orgid, suppressprint=False):
+def getnonmerakivpnpeers(apikey, orgid, suppressprint=False, proxies=None, session=None, verify_access=True):
     #
     # Confirm API Key has Admin Access Otherwise Raise Error
     #
-    __hasorgaccess(apikey, orgid)
+    if verify_access:
+        __hasorgaccess(apikey, orgid)
     calltype = 'Non-Meraki VPN'
 
     geturl = '{0}/organizations/{1}/thirdPartyVPNPeers'.format(str(base_url), str(orgid))
@@ -2093,7 +2269,11 @@ def getnonmerakivpnpeers(apikey, orgid, suppressprint=False):
         'x-cisco-meraki-api-key': format(str(apikey)),
         'Content-Type': 'application/json'
     }
-    dashboard = requests.get(geturl, headers=headers)
+
+    if session:
+        dashboard = session.get(geturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.get(geturl, headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -2103,7 +2283,8 @@ def getnonmerakivpnpeers(apikey, orgid, suppressprint=False):
 
 # Update the third party VPN peers for an organization
 # https://dashboard.meraki.com/api_docs#update-the-third-party-vpn-peers-for-an-organization
-def updatenonmerakivpn(apikey, orgid, names, ips, secrets, remotenets, tags=None, suppressprint=False):
+def updatenonmerakivpn(apikey, orgid, names, ips, secrets, remotenets, tags=None, suppressprint=False,
+                       proxies=None, session=None, verify_access=True):
     #
     # Function to update non-Meraki VPN peer information for an organization.  This function will desctructively
     # overwrite ALL existing peer information.  If you only wish to add/update an existing peer you must download
@@ -2113,7 +2294,8 @@ def updatenonmerakivpn(apikey, orgid, names, ips, secrets, remotenets, tags=None
     #
     # Confirm API Key has Admin Access Otherwise Raise Error
     #
-    __hasorgaccess(apikey, orgid)
+    if verify_access:
+        __hasorgaccess(apikey, orgid)
     calltype = 'Non-Meraki VPN'
 
     puturl = '{0}/organizations/{1}/thirdPartyVPNPeers'.format(str(base_url), str(orgid))
@@ -2156,7 +2338,11 @@ def updatenonmerakivpn(apikey, orgid, names, ips, secrets, remotenets, tags=None
         raise TypeError('All peer arguments must be passed as lists, tags argument may be excluded')
 
     putdata = json.dumps(putdata)
-    dashboard = requests.put(puturl, data=putdata, headers=headers)
+
+    if session:
+        dashboard = session.put(puturl, data=putdata, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.put(puturl, data=putdata, headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -2166,7 +2352,8 @@ def updatenonmerakivpn(apikey, orgid, names, ips, secrets, remotenets, tags=None
 
 # Update the third party VPN peers for an organization
 # https://dashboard.meraki.com/api_docs#update-the-third-party-vpn-peers-for-an-organization
-def appendnonmerakivpn(apikey, orgid, names, ips, secrets, remotenets, tags=None, suppressprint=False):
+def appendnonmerakivpn(apikey, orgid, names, ips, secrets, remotenets, tags=None, suppressprint=False,
+                       proxies=None, session=None, verify_access=True):
     #
     # Function to update non-Meraki VPN peer information for an organization.  This function will desctructively
     # overwrite ALL existing peer information.  If you only wish to add/update an existing peer you must download
@@ -2176,7 +2363,8 @@ def appendnonmerakivpn(apikey, orgid, names, ips, secrets, remotenets, tags=None
     #
     # Confirm API Key has Admin Access Otherwise Raise Error
     #
-    __hasorgaccess(apikey, orgid)
+    if verify_access:
+        __hasorgaccess(apikey, orgid)
     calltype = 'Non-Meraki VPN'
 
     puturl = '{0}/organizations/{1}/thirdPartyVPNPeers'.format(str(base_url), str(orgid))
@@ -2232,7 +2420,11 @@ def appendnonmerakivpn(apikey, orgid, names, ips, secrets, remotenets, tags=None
     else:
         raise TypeError('All peer arguments must be passed as lists, tags argument may be excluded')
     putdata = json.dumps(putdata)
-    dashboard = requests.put(puturl, data=putdata, headers=headers)
+
+    if session:
+        dashboard = session.put(puturl, data=putdata, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.put(puturl, data=putdata, headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -2244,35 +2436,44 @@ def appendnonmerakivpn(apikey, orgid, names, ips, secrets, remotenets, tags=None
 
 # List all phones in a network and their contact assignment
 # https://dashboard.meraki.com/api_docs#list-all-phones-in-a-network-and-their-contact-assignment
-def getphones(apikey, networkid, suppressprint=False):
+def getphones(apikey, networkid, suppressprint=False, proxies=None, session=None):
     calltype = 'Phone Assignments'
     geturl = '{0}/networks/{1}/phoneAssignments'.format(str(base_url), str(networkid))
     headers = {
         'x-cisco-meraki-api-key': format(str(apikey)),
         'Content-Type': 'application/json'
     }
-    dashboard = requests.get(geturl, headers=headers)
+
+    if session:
+        dashboard = requests.get(geturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.get(geturl, headers=headers, proxies=proxies)
     result = __returnhandler(dashboard.status_code, dashboard.text, calltype, suppressprint)
     return result
 
 
 # Return a phone's contact assignment
 # https://dashboard.meraki.com/api_docs#return-a-phones-contact-assignment
-def getphonedetails(apikey, networkid, serial, suppressprint=False):
+def getphonedetails(apikey, networkid, serial, suppressprint=False, proxies=None, session=None):
     calltype = 'Phone Assignment Detail'
     geturl = '{0}/networks/{1}/phoneAssignments/{2}'.format(str(base_url), str(networkid), str(serial))
     headers = {
         'x-cisco-meraki-api-key': format(str(apikey)),
         'Content-Type': 'application/json'
     }
-    dashboard = requests.get(geturl, headers=headers)
+
+    if session:
+        dashboard = session.get(geturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.get(geturl, headers=headers, proxies=proxies)
     result = __returnhandler(dashboard.status_code, dashboard.text, calltype, suppressprint)
     return result
 
 
 # Assign a contact and number(s) to a phone
 # https://dashboard.meraki.com/api_docs#assign-a-contact-and-numbers-to-a-phone
-def updatephonedetails(apikey, networkid, serial, contactid, contacttype, publicnumber=None, ext=None, suppressprint=False):
+def updatephonedetails(apikey, networkid, serial, contactid, contacttype, publicnumber=None, ext=None,
+                       suppressprint=False, proxies=None, session=None):
     calltype = 'Phone Assignment'
     puturl = '{0}/networks/{1}/phoneAssignments/{2}'.format(str(base_url), str(networkid), str(serial))
     headers = {
@@ -2291,21 +2492,28 @@ def updatephonedetails(apikey, networkid, serial, contactid, contacttype, public
 
     putdata = {'contactId': contactid, 'contactType': contacttype, 'publicNumber': publicnumber, 'ext': ext}
 
-    dashboard = requests.put(puturl, data=json.dumps(putdata), headers=headers)
+    if session:
+        dashboard = session.put(puturl, data=json.dumps(putdata), headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.put(puturl, data=json.dumps(putdata), headers=headers, proxies=proxies)
     result = __returnhandler(dashboard.status_code, dashboard.text, calltype, suppressprint)
     return result
 
 
 # Remove a phone assignment (unprovision a phone)
 # https://dashboard.meraki.com/api_docs#remove-a-phone-assignment-unprovision-a-phone
-def delphone(apikey, networkid, serial, suppressprint=False):
+def delphone(apikey, networkid, serial, suppressprint=False, proxies=None, session=None):
     calltype = 'Phone Assignment'
     delurl = '{0}/networks/{1}/phoneAssignments/{2}'.format(str(base_url), str(networkid), str(serial))
     headers = {
         'x-cisco-meraki-api-key': format(str(apikey)),
         'Content-Type': 'application/json'
     }
-    dashboard = requests.delete(delurl, headers=headers)
+
+    if session:
+        dashboard = session.delete(delurl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.delete(delurl, headers=headers, proxies=proxies)
     result = __returnhandler(dashboard.status_code, dashboard.text, calltype, suppressprint)
     return result
 
@@ -2314,7 +2522,7 @@ def delphone(apikey, networkid, serial, suppressprint=False):
 
 # List the phone contacts in a network
 # https://dashboard.meraki.com/api_docs#list-the-phone-contacts-in-a-network
-def getcontacts(apikey, networkid, suppressprint=False):
+def getcontacts(apikey, networkid, suppressprint=False, proxies=None, session=None):
     calltype = 'Phone Contacts'
     geturl = '{0}/networks/{1}/phoneContacts'.format(str(base_url), str(networkid))
     headers = {
@@ -2322,14 +2530,17 @@ def getcontacts(apikey, networkid, suppressprint=False):
         'Content-Type': 'application/json'
     }
 
-    dashboard = requests.get(geturl, headers=headers)
+    if session:
+        dashboard = session.get(geturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.get(geturl, headers=headers, proxies=proxies)
     result = __returnhandler(dashboard.status_code, dashboard.text, calltype, suppressprint)
     return result
 
 
 # Add a contact
 # https://dashboard.meraki.com/api_docs#add-a-contact
-def addcontact(apikey, networkid, name, suppressprint=False):
+def addcontact(apikey, networkid, name, suppressprint=False, proxies=None, session=None):
     calltype = 'Phone Contact'
     posturl = '{0}/networks/{1}/phoneContacts'.format(str(base_url), str(networkid))
     headers = {
@@ -2339,14 +2550,17 @@ def addcontact(apikey, networkid, name, suppressprint=False):
 
     postdata = {'name': name}
     
-    dashboard = requests.post(posturl, data=json.dumps(postdata), headers=headers)
+    if session:
+        dashboard = session.post(posturl, data=json.dumps(postdata), headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.post(posturl, data=json.dumps(postdata), headers=headers, proxies=proxies)
     result = __returnhandler(dashboard.status_code, dashboard.text, calltype, suppressprint)
     return result
 
 
 # Update a phone contact. Google Directory contacts cannot be modified.
 # https://dashboard.meraki.com/api_docs#update-a-phone-contact
-def updatecontact(apikey, networkid, contactid, name, suppressprint=False):
+def updatecontact(apikey, networkid, contactid, name, suppressprint=False, proxies=None, session=None):
     calltype = 'Phone Contact'
     puturl = '{0}/networks/{1}/phoneContacts/{2}'.format(str(base_url), str(networkid), str(contactid))
     headers = {
@@ -2356,14 +2570,17 @@ def updatecontact(apikey, networkid, contactid, name, suppressprint=False):
 
     putdata = {'name': name}
     
-    dashboard = requests.put(puturl, data=json.dumps(putdata), headers=headers)
+    if session:
+        dashboard = session.put(puturl, data=json.dumps(putdata), headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.put(puturl, data=json.dumps(putdata), headers=headers, proxies=proxies)
     result = __returnhandler(dashboard.status_code, dashboard.text, calltype, suppressprint)
     return result
 
 
 # Delete a phone contact. Google Directory contacts cannot be removed.
 # https://dashboard.meraki.com/api_docs#delete-a-phone-contact
-def delcontact(apikey, networkid, contactid, suppressprint=False):
+def delcontact(apikey, networkid, contactid, suppressprint=False, proxies=None, session=None):
     calltype = 'Phone Contact'
     delurl = '{0}/networks/{1}/phoneContacts/{2}'.format(str(base_url), str(networkid), str(contactid))
     headers = {
@@ -2371,7 +2588,10 @@ def delcontact(apikey, networkid, contactid, suppressprint=False):
         'Content-Type': 'application/json'
     }
     
-    dashboard = requests.delete(delurl, headers=headers)
+    if session:
+        dashboard = session.delete(delurl, headers=headers,proxies=proxies)
+    else:
+        dashboard = requests.delete(delurl, headers=headers, proxies=proxies)
     result = __returnhandler(dashboard.status_code, dashboard.text, calltype, suppressprint)
     return result
 
@@ -2380,7 +2600,7 @@ def delcontact(apikey, networkid, contactid, suppressprint=False):
 
 # List all the phone numbers in a network
 # https://dashboard.meraki.com/api_docs#list-all-the-phone-numbers-in-a-network
-def getallnumbers(apikey, networkid, suppressprint=False):
+def getallnumbers(apikey, networkid, suppressprint=False, proxies=None, session=None):
     calltype = 'Phone Numbers'
     geturl = '{0}/networks/{1}/phoneNumbers'.format(str(base_url), str(networkid))
     headers = {
@@ -2388,14 +2608,17 @@ def getallnumbers(apikey, networkid, suppressprint=False):
         'Content-Type': 'application/json'
     }
 
-    dashboard = requests.get(geturl, headers=headers)
+    if session:
+        dashboard = session.get(geturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.get(geturl, headers=headers, proxies=proxies)
     result = __returnhandler(dashboard.status_code, dashboard.text, calltype, suppressprint)
     return result
 
 
 # List the available phone numbers in a network
 # https://dashboard.meraki.com/api_docs#list-the-available-phone-numbers-in-a-network
-def getavailablenumbers(apikey, networkid, suppressprint=False):
+def getavailablenumbers(apikey, networkid, suppressprint=False, proxies=None, session=None):
     calltype = 'Phone Numbers'
     geturl = '{0}/networks/{1}/phoneNumbers/available'.format(str(base_url), str(networkid))
     headers = {
@@ -2403,7 +2626,10 @@ def getavailablenumbers(apikey, networkid, suppressprint=False):
         'Content-Type': 'application/json'
     }
 
-    dashboard = requests.get(geturl, headers=headers)
+    if session:
+        dashboard = session.get(geturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.get(geturl, headers=headers, proxies=proxies)
     result = __returnhandler(dashboard.status_code, dashboard.text, calltype, suppressprint)
     return result
 
@@ -2412,11 +2638,12 @@ def getavailablenumbers(apikey, networkid, suppressprint=False):
 
 # List the SAML roles for this organization
 # https://dashboard.meraki.com/api_docs#list-the-saml-roles-for-this-organization
-def getsamlroles(apikey, orgid, suppressprint=False):
+def getsamlroles(apikey, orgid, suppressprint=False, proxies=None, session=None, verify_access=True):
     #
     # Confirm API Key has Admin Access Otherwise Raise Error
     #
-    __hasorgaccess(apikey, orgid)
+    if verify_access:
+        __hasorgaccess(apikey, orgid)
     calltype = 'SAML Roles'
 
     geturl = '{0}/organizations/{1}/samlRoles'.format(str(base_url), str(orgid))
@@ -2424,7 +2651,11 @@ def getsamlroles(apikey, orgid, suppressprint=False):
         'x-cisco-meraki-api-key': format(str(apikey)),
         'Content-Type': 'application/json'
     }
-    dashboard = requests.get(geturl, headers=headers)
+
+    if session:
+        dashboard = session.get(geturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.get(geturl, headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -2434,11 +2665,12 @@ def getsamlroles(apikey, orgid, suppressprint=False):
 
 # Return a SAML role
 # https://dashboard.meraki.com/api_docs#return-a-saml-role
-def getsamlroledetail(apikey, orgid, roleid, suppressprint=False):
+def getsamlroledetail(apikey, orgid, roleid, suppressprint=False, proxies=None, session=None, verify_access=True):
     #
     # Confirm API Key has Admin Access Otherwise Raise Error
     #
-    __hasorgaccess(apikey, orgid)
+    if verify_access:
+        __hasorgaccess(apikey, orgid)
     calltype = 'SAML Role Detail'
 
     geturl = '{0}/organizations/{1}/samlRoles/{2}'.format(str(base_url), str(orgid), str(roleid))
@@ -2446,7 +2678,11 @@ def getsamlroledetail(apikey, orgid, roleid, suppressprint=False):
         'x-cisco-meraki-api-key': format(str(apikey)),
         'Content-Type': 'application/json'
     }
-    dashboard = requests.get(geturl, headers=headers)
+
+    if session:
+        dashboard = session.get(geturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.get(geturl, headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -2457,11 +2693,12 @@ def getsamlroledetail(apikey, orgid, roleid, suppressprint=False):
 # Update a SAML role
 # https://dashboard.meraki.com/api_docs#update-a-saml-role
 def updatesamlrole(apikey, orgid, roleid, rolename, orgaccess, tags, tagaccess, networks, netaccess,
-                   suppressprint=False):
+                   suppressprint=False, proxies=None, session=None, verify_access=True):
     #
     # Confirm API Key has Admin Access Otherwise Raise Error
     #
-    __hasorgaccess(apikey, orgid)
+    if verify_access:
+        __hasorgaccess(apikey, orgid)
     calltype = 'SAML Role'
 
     puturl = '{0}/organizations/{1}/samlRoles/{2}'.format(str(base_url), str(orgid), str(roleid))
@@ -2539,7 +2776,11 @@ def updatesamlrole(apikey, orgid, roleid, rolename, orgaccess, tags, tagaccess, 
 
     putdata = [roledata]
     print(roledata, putdata, sep='\n')
-    dashboard = requests.put(puturl, data=json.dumps(roledata), headers=headers)
+
+    if session:
+        dashboard = session.put(puturl, data=json.dumps(roledata), headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.put(puturl, data=json.dumps(roledata), headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -2549,11 +2790,13 @@ def updatesamlrole(apikey, orgid, roleid, rolename, orgaccess, tags, tagaccess, 
 
 # Create a SAML role
 # https://dashboard.meraki.com/api_docs#create-a-saml-role
-def addsamlrole(apikey, orgid, rolename, orgaccess, tags, tagaccess, networks, netaccess, suppressprint=False):
+def addsamlrole(apikey, orgid, rolename, orgaccess, tags, tagaccess, networks, netaccess, suppressprint=False,
+                proxies=None, session=None, verify_access=True):
     #
     # Confirm API Key has Admin Access Otherwise Raise Error
     #
-    __hasorgaccess(apikey, orgid)
+    if verify_access:
+        __hasorgaccess(apikey, orgid)
     calltype = 'SAML Role'
 
     posturl = '{0}/organizations/{1}/samlRoles'.format(str(base_url), str(orgid))
@@ -2634,7 +2877,10 @@ def addsamlrole(apikey, orgid, rolename, orgaccess, tags, tagaccess, networks, n
     if netlist is True:
         postdata['networks'] = postnets
 
-    dashboard = requests.post(posturl, data=json.dumps(postdata), headers=headers)
+    if session:
+        dashboard = session.post(posturl, data=json.dumps(postdata), headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.post(posturl, data=json.dumps(postdata), headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -2644,11 +2890,12 @@ def addsamlrole(apikey, orgid, rolename, orgaccess, tags, tagaccess, networks, n
 
 # Remove a SAML role
 # https://dashboard.meraki.com/api_docs#remove-a-saml-role
-def delsamlrole(apikey, orgid, roleid, suppressprint=False):
+def delsamlrole(apikey, orgid, roleid, suppressprint=False, proxies=None, session=None, verify_access=True):
     #
     # Confirm API Key has Admin Access Otherwise Raise Error
     #
-    __hasorgaccess(apikey, orgid)
+    if verify_access:
+        __hasorgaccess(apikey, orgid)
     calltype = 'SAML Role'
 
     delurl = '{0}/organizations/{1}/samlRoles/{2}'.format(str(base_url), str(orgid), str(roleid))
@@ -2656,7 +2903,11 @@ def delsamlrole(apikey, orgid, roleid, suppressprint=False):
         'x-cisco-meraki-api-key': format(str(apikey)),
         'Content-Type': 'application/json'
     }
-    dashboard = requests.delete(delurl, headers=headers)
+
+    if session:
+        dashboard = session.delete(delurl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.delete(delurl, headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -2668,7 +2919,8 @@ def delsamlrole(apikey, orgid, roleid, suppressprint=False):
 
 # List the devices enrolled in an SM network with various specified fields and filters
 # https://dashboard.meraki.com/api_docs#list-the-devices-enrolled-in-an-sm-network-with-various-specified-fields-and-filters
-def getsmdevices(apikey, networkid, fields=None, wifimacs=None, serials=None, ids=None, scope=None, token=None, suppressprint=False):
+def getsmdevices(apikey, networkid, fields=None, wifimacs=None, serials=None, ids=None, scope=None, token=None,
+                 suppressprint=False, proxies=None, session=None):
     defaultfields = ['id', 'name', 'tags', 'ssid', 'wifiMac', 'osName', 'systemModel', 'uuid', 'serialNumber']
     possiblefields = ['ip', 'systemType', 'availableDeviceCapacity', 'kioskAppName', 'biosVersion', 'lastConnected', 'missingAppsCount', 'userSuppliedAddress', 'location', 'lastUser', 'publicIp', 'phoneNumber', 'diskInfoJson', 'deviceCapacity', 'isManaged', 'hadMdm', 'isSupervised', 'meid', 'imei', 'iccid', 'simCarrierNetwork', 'cellularDataUsed', 'isHotspotEnabled', 'createdAt', 'batteryEstCharge', 'quarantined', 'avName', 'avRunning', 'asName', 'fwName', 'isRooted', 'loginRequired', 'screenLockEnabled', 'screenLockDelay', 'autoLoginDisabled', 'hasMdm', 'hasDesktopAgent', 'diskEncryptionEnabled', 'hardwareEncryptionCaps', 'passCodeLock']
 
@@ -2698,15 +2950,18 @@ def getsmdevices(apikey, networkid, fields=None, wifimacs=None, serials=None, id
                 raise ValueError('Scope (one of all, none, withAny, withAll, withoutAny, or withoutAll) must be specified')
             geturl += 'scope=' + scope
 
-
-    dashboard = requests.get(geturl, headers=headers)
+    if session:
+        dashboard = session.get(geturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.get(geturl, headers=headers, proxies=proxies)
     result = __returnhandler(dashboard.status_code, dashboard.text, calltype, suppressprint)
     return result
 
 
 # Add, delete, or update the tags of a set of devices
 # https://dashboard.meraki.com/api_docs#add-delete-or-update-the-tags-of-a-set-of-devices
-def updatesmtags(apikey, networkid, tags, action, wifimacs=None, ids=None, serials=None, scope=None, suppressprint=False):
+def updatesmtags(apikey, networkid, tags, action, wifimacs=None, ids=None, serials=None, scope=None,
+                 suppressprint=False, proxies=None, session=None):
     calltype = 'Systems Manager'
     puturl = '{0}/networks/{1}/sm/devices/tags'.format(str(base_url), str(networkid))
     headers = {
@@ -2731,14 +2986,18 @@ def updatesmtags(apikey, networkid, tags, action, wifimacs=None, ids=None, seria
             raise ValueError('Parameter scope (one of all, none, withAny, withAll, withoutAny, or withoutAll) must be specified')
         putdata['scope'] = scope
     
-    dashboard = requests.put(puturl, data=json.dumps(putdata), headers=headers)
+    if session:
+        dashboard = session.put(puturl, data=json.dumps(putdata), headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.put(puturl, data=json.dumps(putdata), headers=headers, proxies=proxies)
     result = __returnhandler(dashboard.status_code, dashboard.text, calltype, suppressprint)
     return result
 
 
 # Modify the fields of a device
 # https://dashboard.meraki.com/api_docs#modify-the-fields-of-a-device
-def updatesmfields(apikey, networkid, wifimac=None, deviceid=None, serial=None, name=None, notes=None, suppressprint=False):
+def updatesmfields(apikey, networkid, wifimac=None, deviceid=None, serial=None, name=None, notes=None,
+                   suppressprint=False, proxies=None, session=None):
     calltype = 'Systems Manager'
     puturl = '{0}/networks/{1}/sm/device/fields'.format(str(base_url), str(networkid))
     headers = {
@@ -2761,14 +3020,18 @@ def updatesmfields(apikey, networkid, wifimac=None, deviceid=None, serial=None, 
     if notes != None:
         putdata['deviceFields']['notes'] = notes
 
-    dashboard = requests.put(puturl, data=json.dumps(putdata), headers=headers)
+    if session:
+        dashboard = session.put(puturl, data=json.dumps(putdata), headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.put(puturl, data=json.dumps(putdata), headers=headers, proxies=proxies)
     result = __returnhandler(dashboard.status_code, dashboard.text, calltype, suppressprint)
     return result
 
 
 # Lock a set of devices
 # https://dashboard.meraki.com/api_docs#lock-a-set-of-devices
-def lockdevices(apikey, networkid, wifimacs=None, ids=None, serials=None, scope=None, pin=None, suppressprint=False):
+def lockdevices(apikey, networkid, wifimacs=None, ids=None, serials=None, scope=None, pin=None,
+                suppressprint=False, proxies=None, session=None):
     calltype = 'Systems Manager'
     puturl = '{0}/networks/{1}/sm/devices/lock'.format(str(base_url), str(networkid))
     headers = {
@@ -2794,14 +3057,18 @@ def lockdevices(apikey, networkid, wifimacs=None, ids=None, serials=None, scope=
             raise ValueError('Parameter pin is a six digit number required only for locking macOS devices')
         putdata['pin'] = pin
 
-    dashboard = requests.put(puturl, data=json.dumps(putdata), headers=headers)
+    if session:
+        dashboard = session.put(puturl, data=json.dumps(putdata), headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.put(puturl, data=json.dumps(putdata), headers=headers, proxies=proxies)
     result = __returnhandler(dashboard.status_code, dashboard.text, calltype, suppressprint)
     return result
 
 
 # Wipe a device
 # https://dashboard.meraki.com/api_docs#wipe-a-device
-def wipedevices(apikey, networkid, wifimacs=None, ids=None, serials=None, scope=None, pin=None, suppressprint=False):
+def wipedevices(apikey, networkid, wifimacs=None, ids=None, serials=None, scope=None, pin=None,
+                suppressprint=False, proxies=None, session=None):
     calltype = 'Systems Manager'
     puturl = '{0}/networks/{1}/sm/devices/wipe'.format(str(base_url), str(networkid))
     headers = {
@@ -2827,14 +3094,18 @@ def wipedevices(apikey, networkid, wifimacs=None, ids=None, serials=None, scope=
             raise ValueError('Parameter pin is a six digit number required only for wiping macOS devices')
         putdata['pin'] = pin
 
-    dashboard = requests.put(puturl, data=json.dumps(putdata), headers=headers)
+    if session:
+        dashboard = session.put(puturl, data=json.dumps(putdata), headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.put(puturl, data=json.dumps(putdata), headers=headers, proxies=proxies)
     result = __returnhandler(dashboard.status_code, dashboard.text, calltype, suppressprint)
     return result
 
 
 # Force check-in a set of devices
 # https://dashboard.meraki.com/api_docs#force-check-in-a-set-of-devices
-def checkindevices(apikey, networkid, wifimacs=None, ids=None, serials=None, scope=None, suppressprint=False):
+def checkindevices(apikey, networkid, wifimacs=None, ids=None, serials=None, scope=None,
+                   suppressprint=False, proxies=None, session=None):
     calltype = 'Systems Manager'
     puturl = '{0}/networks/{1}/sm/devices/checkin'.format(str(base_url), str(networkid))
     headers = {
@@ -2856,14 +3127,18 @@ def checkindevices(apikey, networkid, wifimacs=None, ids=None, serials=None, sco
             raise ValueError('Parameter scope (one of all, none, withAny, withAll, withoutAny, or withoutAll) must be specified')
         putdata['scope'] = scope
 
-    dashboard = requests.put(puturl, data=json.dumps(putdata), headers=headers)
+    if session:
+        dashboard = session.put(puturl, data=json.dumps(putdata), headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.put(puturl, data=json.dumps(putdata), headers=headers, proxies=proxies)
     result = __returnhandler(dashboard.status_code, dashboard.text, calltype, suppressprint)
     return result
 
 
 # Move a set of devices to a new network
 # https://dashboard.meraki.com/api_docs#move-a-set-of-devices-to-a-new-network
-def movedevices(apikey, networkid, newnetid, wifimacs=None, ids=None, serials=None, scope=None, suppressprint=False):
+def movedevices(apikey, networkid, newnetid, wifimacs=None, ids=None, serials=None, scope=None,
+                suppressprint=False, proxies=None, session=None):
     calltype = 'Systems Manager'
     puturl = '{0}/networks/{1}/sm/devices/move'.format(str(base_url), str(networkid))
     headers = {
@@ -2886,7 +3161,10 @@ def movedevices(apikey, networkid, newnetid, wifimacs=None, ids=None, serials=No
             raise ValueError('Parameter scope (one of all, none, withAny, withAll, withoutAny, or withoutAll) must be specified')
         putdata['scope'] = scope
 
-    dashboard = requests.put(puturl, data=json.dumps(putdata), headers=headers)
+    if session:
+        dashboard = session.put(puturl, data=json.dumps(putdata), headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.put(puturl, data=json.dumps(putdata), headers=headers, proxies=proxies)
     result = __returnhandler(dashboard.status_code, dashboard.text, calltype, suppressprint)
     return result
 
@@ -2895,14 +3173,18 @@ def movedevices(apikey, networkid, newnetid, wifimacs=None, ids=None, serials=No
 
 # List the SSIDs in a network
 # https://dashboard.meraki.com/api_docs#list-the-ssids-in-a-network
-def getssids(apikey, networkid, suppressprint=False):
+def getssids(apikey, networkid, suppressprint=False, proxies=None, session=None):
     calltype = 'SSID'
     geturl = '{0}/networks/{1}/ssids'.format(str(base_url), str(networkid))
     headers = {
         'x-cisco-meraki-api-key': format(str(apikey)),
         'Content-Type': 'application/json'
     }
-    dashboard = requests.get(geturl, headers=headers)
+
+    if session:
+        dashboard = session.get(geturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.get(geturl, headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -2912,14 +3194,18 @@ def getssids(apikey, networkid, suppressprint=False):
 
 # Return a single SSID
 # https://dashboard.meraki.com/api_docs#return-a-single-ssid
-def getssiddetail(apikey, networkid, ssidnum, suppressprint=False):
+def getssiddetail(apikey, networkid, ssidnum, suppressprint=False, proxies=None, session=None):
     calltype = 'SSID Detail'
     geturl = '{0}/networks/{1}/ssids/{2}'.format(str(base_url), str(networkid), str(ssidnum))
     headers = {
         'x-cisco-meraki-api-key': format(str(apikey)),
         'Content-Type': 'application/json'
     }
-    dashboard = requests.get(geturl, headers=headers)
+
+    if session:
+        dashboard = session.get(geturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.get(geturl, headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -2929,7 +3215,8 @@ def getssiddetail(apikey, networkid, ssidnum, suppressprint=False):
 
 # Update the attributes of an SSID
 # https://dashboard.meraki.com/api_docs#update-the-attributes-of-an-ssid
-def updatessid(apikey, networkid, ssidnum, name, enabled, authmode, encryptionmode, psk, suppressprint=False):
+def updatessid(apikey, networkid, ssidnum, name, enabled, authmode, encryptionmode, psk, suppressprint=False,
+               proxies=None, session=None):
 
     calltype = 'SSID'
     puturl = '{0}/networks/{1}/ssids/{2}'.format(str(base_url), str(networkid), str(ssidnum))
@@ -2974,7 +3261,10 @@ def updatessid(apikey, networkid, ssidnum, name, enabled, authmode, encryptionmo
     elif psk:
         putdata['psk'] = str(psk)
 
-    dashboard = requests.put(puturl, data=json.dumps(putdata), headers=headers)
+    if session:
+        dashboard = session.put(puturl, data=json.dumps(putdata), headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.put(puturl, data=json.dumps(putdata), headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -2984,7 +3274,7 @@ def updatessid(apikey, networkid, ssidnum, name, enabled, authmode, encryptionmo
 
 # Update the attributes of an SSID
 # https://dashboard.meraki.com/api_docs#update-the-attributes-of-an-ssid
-def updatessidobject(apikey, networkid, newssid: SSID, suppressprint=False):
+def updatessidobject(apikey, networkid, newssid: SSID, suppressprint=False, proxies=None, session=None):
     '''
 
     Args:
@@ -3006,7 +3296,11 @@ def updatessidobject(apikey, networkid, newssid: SSID, suppressprint=False):
         puturl = '{0}/networks/{1}/ssids/{2}'.format(str(base_url), str(networkid), newssid.ssidnum)
 
     putdata = json.dumps(newssid.__dict__)
-    dashboard = requests.put(puturl, data=putdata, headers=headers)
+
+    if session:
+        dashboard = session.put(puturl, data=putdata, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.put(puturl, data=putdata, headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -3018,7 +3312,7 @@ def updatessidobject(apikey, networkid, newssid: SSID, suppressprint=False):
 
 # List the static routes for this network
 # https://dashboard.meraki.com/api_docs#list-the-static-routes-for-this-network
-def getstaticroutes(apikey, networkid, suppressprint=False):
+def getstaticroutes(apikey, networkid, suppressprint=False, proxies=None, session=None):
     calltype = 'Static Routes'
     geturl = '{0}/networks/{1}/staticRoutes'.format(str(base_url), str(networkid))
     headers = {
@@ -3026,14 +3320,17 @@ def getstaticroutes(apikey, networkid, suppressprint=False):
         'Content-Type': 'application/json'
     }
 
-    dashboard = requests.get(geturl, headers=headers)
+    if session:
+        dashboard = session.get(geturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.get(geturl, headers=headers, proxies=proxies)
     result = __returnhandler(dashboard.status_code, dashboard.text, calltype, suppressprint)
     return result
 
 
 # Return a static route
 # https://dashboard.meraki.com/api_docs#return-a-static-route
-def getstaticroutedetail(apikey, networkid, routeid, suppressprint=False):
+def getstaticroutedetail(apikey, networkid, routeid, suppressprint=False, proxies=None, session=None):
     calltype = 'Static Route Detail'
     geturl = '{0}/networks/{1}/staticRoutes/{2}'.format(str(base_url), str(networkid), str(routeid))
     headers = {
@@ -3041,14 +3338,19 @@ def getstaticroutedetail(apikey, networkid, routeid, suppressprint=False):
         'Content-Type': 'application/json'
     }
 
-    dashboard = requests.get(geturl, headers=headers)
+    if session:
+        dashboard = session.get(geturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.get(geturl, headers=headers, proxies=proxies)
     result = __returnhandler(dashboard.status_code, dashboard.text, calltype, suppressprint)
     return result
 
 
 # Update a static route
 # https://dashboard.meraki.com/api_docs#update-a-static-route
-def updatestaticroute(apikey, networkid, routeid, name=None, subnet=None, gatewayip=None, enabled=None, fixedipassignments=None, reservedipranges=None, suppressprint=False):
+def updatestaticroute(apikey, networkid, routeid, name=None, subnet=None, gatewayip=None, enabled=None,
+                      fixedipassignments=None, reservedipranges=None, suppressprint=False,
+                      proxies=None, session=None):
     calltype = 'Static Route'
     puturl = '{0}/networks/{1}/staticRoutes/{2}'.format(str(base_url), str(networkid), str(routeid))
     headers = {
@@ -3070,14 +3372,18 @@ def updatestaticroute(apikey, networkid, routeid, name=None, subnet=None, gatewa
         putdata['reservedIpRanges'] = format(str(reservedipranges))
 
     putdata = json.dumps(putdata)
-    dashboard = requests.put(puturl, data=putdata, headers=headers)
+
+    if session:
+        dashboard = session.put(puturl, data=putdata, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.put(puturl, data=putdata, headers=headers, proxies=proxies)
     result = __returnhandler(dashboard.status_code, dashboard.text, calltype, suppressprint)
     return result
 
 
 # Add a static route
 # https://dashboard.meraki.com/api_docs#add-a-static-route
-def addstaticroute(apikey, networkid, name, subnet, ip, suppressprint=False):
+def addstaticroute(apikey, networkid, name, subnet, ip, suppressprint=False, proxies=None, session=None):
     calltype = 'Static Route'
     posturl = '{0}/networks/{1}/staticRoutes'.format(str(base_url), str(networkid))
     headers = {
@@ -3090,14 +3396,17 @@ def addstaticroute(apikey, networkid, name, subnet, ip, suppressprint=False):
         'gatewayIp': format(str(ip))
     }
     
-    dashboard = requests.post(posturl, data=json.dumps(postdata), headers=headers)
+    if session:
+        dashboard = session.post(posturl, data=json.dumps(postdata), headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.post(posturl, data=json.dumps(postdata), headers=headers, proxies=proxies)
     result = __returnhandler(dashboard.status_code, dashboard.text, calltype, suppressprint)
     return result
 
 
 # Delete a static route from a network
 # https://dashboard.meraki.com/api_docs#delete-a-static-route-from-a-network
-def delstaticroute(apikey, networkid, routeid, suppressprint=False):
+def delstaticroute(apikey, networkid, routeid, suppressprint=False, proxies=None, session=None):
     calltype = 'Static Route'
     delurl = '{0}/networks/{1}/staticRoutes/{2}'.format(str(base_url), str(networkid), str(routeid))
     headers = {
@@ -3105,7 +3414,10 @@ def delstaticroute(apikey, networkid, routeid, suppressprint=False):
         'Content-Type': 'application/json'
     }
 
-    dashboard = requests.delete(delurl, headers=headers)
+    if session:
+        dashboard = session.delete(delurl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.delete(delurl, headers=headers, proxies=proxies)
     result = __returnhandler(dashboard.status_code, dashboard.text, calltype, suppressprint)
     return result
 
@@ -3114,14 +3426,18 @@ def delstaticroute(apikey, networkid, routeid, suppressprint=False):
 
 # List the switch ports for a switch
 # https://dashboard.meraki.com/api_docs#list-the-switch-ports-for-a-switch
-def getswitchports(apikey, serialnum, suppressprint=False):
+def getswitchports(apikey, serialnum, suppressprint=False, proxies=None, session=None):
     calltype = 'Switch Port'
     geturl = '{0}/devices/{1}/switchPorts'.format(str(base_url), str(serialnum))
     headers = {
         'x-cisco-meraki-api-key': format(str(apikey)),
         'Content-Type': 'application/json'
     }
-    dashboard = requests.get(geturl, headers=headers)
+
+    if session:
+        dashboard = session.get(geturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.get(geturl, headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -3131,14 +3447,18 @@ def getswitchports(apikey, serialnum, suppressprint=False):
 
 # Return a switch port
 # https://dashboard.meraki.com/api_docs#return-a-switch-port
-def getswitchportdetail(apikey, serialnum, portnum, suppressprint=False):
+def getswitchportdetail(apikey, serialnum, portnum, suppressprint=False, proxies=None, session=None):
     calltype = 'Switch Port Detail'
     geturl = '{0}/devices/{1}/switchPorts/{2}'.format(str(base_url), str(serialnum), str(portnum))
     headers = {
         'x-cisco-meraki-api-key': format(str(apikey)),
         'Content-Type': 'application/json'
     }
-    dashboard = requests.get(geturl, headers=headers)
+
+    if session:
+        dashboard = session.get(geturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.get(geturl, headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -3148,8 +3468,9 @@ def getswitchportdetail(apikey, serialnum, portnum, suppressprint=False):
 
 # Update a switch port
 # https://dashboard.meraki.com/api_docs#update-a-switch-port
-def updateswitchport(apikey, serialnum, portnum, name, tags, enabled, porttype, vlan, voicevlan, allowedvlans, poe,
-                     isolation, rstp, stpguard, accesspolicynum, suppressprint=False):
+def updateswitchport(apikey, serialnum, portnum, name=None, tags=None, enabled=None, porttype=None, vlan=None,
+                     voicevlan=None, allowedvlans=None, poe=None, isolation=None, rstp=None, stpguard=None,
+                     accesspolicynum=None, suppressprint=False, proxies=None, session=None):
 
     calltype = 'Switch Port'
     puturl = '{0}/devices/{1}/switchPorts/{2}'.format(str(base_url), str(serialnum), str(portnum))
@@ -3160,55 +3481,58 @@ def updateswitchport(apikey, serialnum, portnum, name, tags, enabled, porttype, 
 
     putdata = {}
 
-    if name in locals():
+    if name:
         putdata['name'] = str(name)
 
-    if tags in locals():
+    if tags:
         putdata['tags'] = __listtotag(tags)
 
-    if enabled in locals() and not isinstance(enabled, bool):
+    if enabled and not isinstance(enabled, bool):
         raise ValueError("Enabled must be a boolean variable")
-    elif enabled in locals():
+    elif enabled:
         putdata['enabled'] = str(enabled)
 
-    if porttype in locals() and porttype not in ['access', 'trunk']:
+    if porttype and porttype not in ['access', 'trunk']:
         raise ValueError("Type must be either 'access' or 'trunk'")
-    elif porttype in locals():
+    elif porttype:
         putdata['type'] = str(porttype)
 
-    if vlan in locals():
+    if vlan:
         putdata['vlan'] = str(vlan)
 
-    if voicevlan in locals():
+    if voicevlan:
         putdata['voiceVlan'] = voicevlan
 
-    if allowedvlans in locals():
+    if allowedvlans:
         putdata['allowedVlans'] = allowedvlans
 
-    if poe in locals and not isinstance(poe, bool):
+    if poe and not isinstance(poe, bool):
         raise ValueError("PoE enabled must be a boolean variable")
-    elif poe in locals():
+    elif poe:
         putdata['poeEnabled'] = str(poe)
 
-    if isolation in locals() and not isinstance(isolation, bool):
+    if isolation and not isinstance(isolation, bool):
         raise ValueError("Port isolation enabled must be a bolean variable")
     elif isolation in locals():
         putdata['isolation'] = isolation
 
-    if rstp in locals() and not isinstance(rstp,bool):
+    if rstp and not isinstance(rstp,bool):
         raise ValueError("RSTP enabled must be a boolean variable")
-    elif rstp in locals():
+    elif rstp:
         putdata['rstpEnabled'] = rstp
 
-    if stpguard in locals() and stpguard not in ['disabled', 'root guard', 'BPDU guard']:
+    if stpguard and stpguard not in ['disabled', 'root guard', 'BPDU guard']:
         raise ValueError("Valid values for STP Guard are 'disabled', 'root guard',  or 'BPDU Guard'")
-    elif stpguard in locals():
+    elif stpguard:
         putdata['stpGuard'] = stpguard
 
-    if accesspolicynum in locals():
+    if accesspolicynum:
         putdata['accessPolicyNumber'] = accesspolicynum
 
-    dashboard = requests.put(puturl, data=json.dumps(putdata), headers=headers)
+    if session:
+        dashboard = session.put(puturl, data=json.dumps(putdata), headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.put(puturl, data=json.dumps(putdata), headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -3220,14 +3544,18 @@ def updateswitchport(apikey, serialnum, portnum, name, tags, enabled, porttype, 
 
 # List the VLANs for this network
 # https://dashboard.meraki.com/api_docs#list-the-vlans-for-this-network
-def getvlans(apikey, networkid, suppressprint=False):
+def getvlans(apikey, networkid, suppressprint=False, proxies=None, session=None):
     calltype = 'VLANs'
     geturl = '{0}/networks/{1}/vlans'.format(str(base_url), str(networkid))
     headers = {
         'x-cisco-meraki-api-key': format(str(apikey)),
         'Content-Type': 'application/json'
     }
-    dashboard = requests.get(geturl, headers=headers)
+
+    if session:
+        dashboard = session.get(geturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.get(geturl, headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -3237,14 +3565,18 @@ def getvlans(apikey, networkid, suppressprint=False):
 
 # Return a VLAN
 # https://dashboard.meraki.com/api_docs#return-a-vlan
-def getvlandetail(apikey, networkid, vlanid, suppressprint=False):
+def getvlandetail(apikey, networkid, vlanid, suppressprint=False, proxies=None, session=None):
     calltype = 'VLAN Detail'
     geturl = '{0}/networks/{1}/vlans/{2}'.format(str(base_url), str(networkid), str(vlanid))
     headers = {
         'x-cisco-meraki-api-key': format(str(apikey)),
         'Content-Type': 'application/json'
     }
-    dashboard = requests.get(geturl, headers=headers)
+
+    if session:
+        dashboard = session.get(geturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.get(geturl, headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -3254,7 +3586,9 @@ def getvlandetail(apikey, networkid, vlanid, suppressprint=False):
 
 # Update a VLAN
 # https://dashboard.meraki.com/api_docs#update-a-vlan
-def updatevlan(apikey, networkid, vlanid, name=None, subnet=None, mxip=None, fixedipassignments=None, reservedipranges=None, vpnnatsubnet=None, dnsnameservers=None, suppressprint=False):
+def updatevlan(apikey, networkid, vlanid, name=None, subnet=None, mxip=None, fixedipassignments=None,
+               reservedipranges=None, vpnnatsubnet=None, dnsnameservers=None, suppressprint=False,
+               proxies=None, session=None):
     # fixedipassignments = {'13:37:de:ad:be:ef': {'ip': '192.168.1.5', 'name': 'fixed'}}
     # reservedipranges = [{'start': '192.168.1.20', 'end': '192.168.1.30', 'comment': 'reserved'}]
     calltype = 'VLAN'
@@ -3280,7 +3614,11 @@ def updatevlan(apikey, networkid, vlanid, name=None, subnet=None, mxip=None, fix
         putdata['dnsNameservers'] = format(str(dnsnameservers))
 
     putdata = json.dumps(putdata)
-    dashboard = requests.put(puturl, data=putdata, headers=headers)
+
+    if session:
+        dashboard = session.put(puturl, data=putdata, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.put(puturl, data=putdata, headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -3290,7 +3628,7 @@ def updatevlan(apikey, networkid, vlanid, name=None, subnet=None, mxip=None, fix
 
 # Add a VLAN
 # https://dashboard.meraki.com/api_docs#add-a-vlan
-def addvlan(apikey, networkid, vlanid, name, subnet, mxip, suppressprint=False):
+def addvlan(apikey, networkid, vlanid, name, subnet, mxip, suppressprint=False, proxies=None, session=None):
     calltype = 'VLAN'
     posturl = '{0}/networks/{1}/vlans'.format(str(base_url), str(networkid))
     headers = {
@@ -3309,7 +3647,11 @@ def addvlan(apikey, networkid, vlanid, name, subnet, mxip, suppressprint=False):
         
     }
     postdata = json.dumps(postdata)
-    dashboard = requests.post(posturl, data=postdata, headers=headers)
+
+    if session:
+        dashboard = session.post(posturl, data=postdata, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.post(posturl, data=postdata, headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -3319,14 +3661,18 @@ def addvlan(apikey, networkid, vlanid, name, subnet, mxip, suppressprint=False):
 
 # Delete a VLAN from a network
 # https://dashboard.meraki.com/api_docs#delete-a-vlan-from-a-network
-def delvlan(apikey, networkid, vlanid, suppressprint=False):
+def delvlan(apikey, networkid, vlanid, suppressprint=False, proxies=None, session=None):
     calltype = 'VLAN'
     delurl = '{0}/networks/{1}/vlans/{2}'.format(str(base_url), str(networkid), str(vlanid))
     headers = {
         'x-cisco-meraki-api-key': format(str(apikey)),
         'Content-Type': 'application/json'
     }
-    dashboard = requests.delete(delurl, headers=headers)
+
+    if session:
+        dashboard = session.delete(delurl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.delete(delurl, headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #
@@ -3334,15 +3680,18 @@ def delvlan(apikey, networkid, vlanid, suppressprint=False):
     return result
 
 
-
 # MX performance score
-def getmxperf(apikey, networkid, serial, suppressprint=False):
+def getmxperf(apikey, networkid, serial, suppressprint=False, proxies=None, session=None):
     calltype = 'MX Performance Detail'
     geturl = '{0}/networks/{1}/devices/{2}/performance'.format(str(base_url), str(networkid), str(serial))
     headers = {
         'x-cisco-meraki-api-key': format(str(apikey)),
         'Content-Type': 'application/json'
     }
-    dashboard = requests.get(geturl, headers=headers)
+
+    if session:
+        dashboard = session.get(geturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.get(geturl, headers=headers, proxies=proxies)
     result = __returnhandler(dashboard.status_code, dashboard.text, calltype, suppressprint)
     return result

--- a/meraki.py
+++ b/meraki.py
@@ -974,12 +974,11 @@ def __returnhandler(statuscode, returntext, objtype, suppressprint):
         print('HTTP Status Code: {0} - No returned data\n'.format(str(statuscode)))
 
 
-
 ### ADMINS ###
 
 # List the dashboard administrators in this organization
 # https://dashboard.meraki.com/api_docs#list-the-dashboard-administrators-in-this-organization
-def getorgadmins(apikey, orgid, suppressprint=False):
+def getorgadmins(apikey, orgid, suppressprint=False, proxies=None, session=None):
     """
 
     Args:
@@ -998,7 +997,10 @@ def getorgadmins(apikey, orgid, suppressprint=False):
         'x-cisco-meraki-api-key': format(str(apikey)),
         'Content-Type': 'application/json'
     }
-    dashboard = requests.get(geturl, headers=headers)
+    if session:
+        dashboard = session.get(geturl, headers=headers, proxies=proxies)
+    else:
+        dashboard = requests.get(geturl, headers=headers, proxies=proxies)
     #
     # Call return handler function to parse Dashboard response
     #

--- a/meraki.py
+++ b/meraki.py
@@ -779,7 +779,7 @@ def __comparelist(*args):
         return 0
 
 
-def __hasorgaccess(apikey, targetorg):
+def __hasorgaccess(apikey, targetorg, proxies=None):
     """
 
     Args:
@@ -795,7 +795,7 @@ def __hasorgaccess(apikey, targetorg):
         'Content-Type': 'application/json'
     }
 
-    dashboard = requests.get(geturl, headers=headers)
+    dashboard = requests.get(geturl, headers=headers, proxies=proxies)
     currentorgs = json.loads(dashboard.text)
     orgs = []
     validjson = __isjson(dashboard.text)
@@ -990,7 +990,7 @@ def getorgadmins(apikey, orgid, suppressprint=False, proxies=None, session=None,
 
     """
     if verify_access:
-        __hasorgaccess(apikey, orgid)
+        __hasorgaccess(apikey, orgid, proxies=proxies)
     calltype = 'Organization'
 
     geturl = '{0}/organizations/{1}/admins'.format(str(base_url), str(orgid))
@@ -1017,7 +1017,7 @@ def addadmin(apikey, orgid, email, name, orgaccess=None, tags=None, tagaccess=No
     # Confirm API Key has Admin Access Otherwise Raise Error
     #
     if verify_access:
-        __hasorgaccess(apikey, orgid)
+        __hasorgaccess(apikey, orgid, proxies=proxies)
     calltype = 'Administrator'
 
     posturl = '{0}/organizations/{1}/admins'.format(str(base_url), str(orgid))
@@ -1131,7 +1131,7 @@ def updateadmin(apikey, orgid, adminid, email, name=None, orgaccess=None, tags=N
     # Confirm API Key has Admin Access Otherwise Raise Error
     #
     if verify_access:
-        __hasorgaccess(apikey, orgid)
+        __hasorgaccess(apikey, orgid, proxies=proxies)
     calltype = 'Administrator'
 
     puturl = '{0}/organizations/{1}/admins/{2}'.format(str(base_url), str(orgid), str(adminid))
@@ -1270,7 +1270,7 @@ def deladmin(apikey, orgid, adminid, suppressprint=False, proxies=None, session=
     # Confirm API Key has Admin Access Otherwise Raise Error
     #
     if verify_access:
-        __hasorgaccess(apikey, orgid)
+        __hasorgaccess(apikey, orgid, proxies=proxies)
     calltype = 'Administrator'
 
     delurl = '{0}/organizations/{1}/admins/{2}'.format(str(base_url), str(orgid), str(adminid))
@@ -1320,7 +1320,7 @@ def gettemplates(apikey, orgid, suppressprint=False, proxies=None, session=None,
     # Confirm API Key has Admin Access Otherwise Raise Error
     #
     if verify_access:
-        __hasorgaccess(apikey, orgid)
+        __hasorgaccess(apikey, orgid, proxies=proxies)
     calltype = 'Templates'
 
     geturl = '{0}/organizations/{1}/configTemplates'.format(str(base_url), str(orgid))
@@ -1346,7 +1346,7 @@ def deltemplate(apikey, orgid, templateid, suppressprint=False, proxies=None, se
     # Confirm API Key has Admin Access Otherwise Raise Error
     #
     if verify_access:
-        __hasorgaccess(apikey, orgid)
+        __hasorgaccess(apikey, orgid, proxies=proxies)
     calltype = 'Template'
 
     delurl = '{0}/organizations/{1}/configTemplates/{2}'.format(str(base_url), str(orgid), str(templateid))
@@ -1613,7 +1613,7 @@ def getnetworklist(apikey, orgid, templateid=None, suppressprint=False, proxies=
     # Confirm API Key has Admin Access Otherwise Raise Error
     #
     if verify_access:
-        __hasorgaccess(apikey, orgid)
+        __hasorgaccess(apikey, orgid, proxies=proxies)
     calltype = 'Network'
 
     geturl = '{0}/organizations/{1}/networks'.format(str(base_url), str(orgid))
@@ -1701,7 +1701,7 @@ def addnetwork(apikey, orgid, name, nettype, tags, tz, suppressprint=False, prox
     Otput: JSON string returned from Dashboard API Call
     """
     if verify_access:
-        __hasorgaccess(apikey, orgid)
+        __hasorgaccess(apikey, orgid, proxies=proxies)
     calltype = 'Network'
 
     posturl = '{0}/organizations/{1}/networks'.format(str(base_url), str(orgid))
@@ -1989,7 +1989,7 @@ def getorg(apikey, orgid, suppressprint=False, proxies=None, session=None):
 # Update an organization
 # https://dashboard.meraki.com/api_docs#update-an-organization
 def renameorg(apikey, orgid, neworgname, suppressprint=False, proxies=None, session=None, verify_access=True):
-    __hasorgaccess(apikey, orgid)
+    __hasorgaccess(apikey, orgid, proxies=proxies)
     calltype = 'Organization Rename'
     puturl = '{0}/organizations/{1}'.format(str(base_url), str(orgid))
     headers = {
@@ -2039,7 +2039,7 @@ def addorg(apikey, neworgname, suppressprint=False, proxies=None, session=None):
 # https://dashboard.meraki.com/api_docs#create-a-new-organization-by-cloning-the-addressed-organization
 def cloneorg(apikey, orgid, neworgname, suppressprint=False, proxies=None, session=None, verify_access=True):
     if verify_access:
-        __hasorgaccess(apikey, orgid)
+        __hasorgaccess(apikey, orgid, proxies=proxies)
     calltype = 'Organization Clone'
     posturl = '{0}/organizations/{1}/clone'.format(str(base_url), str(orgid))
     headers = {
@@ -2109,7 +2109,7 @@ def getlicensestate(apikey, orgid, suppressprint=False, proxies=None, session=No
     # Confirm API Key has Admin Access Otherwise Raise Error
     #
     if verify_access:
-        __hasorgaccess(apikey, orgid)
+        __hasorgaccess(apikey, orgid, proxies=proxies)
     calltype = 'License'
 
     geturl = '{0}/organizations/{1}/licenseState'.format(str(base_url), str(orgid))
@@ -2143,7 +2143,7 @@ def getorginventory(apikey, orgid, suppressprint=False, proxies=None, session=No
 
     """
     if verify_access:
-        __hasorgaccess(apikey, orgid)
+        __hasorgaccess(apikey, orgid, proxies=proxies)
     calltype = 'Inventory'
 
     geturl = '{0}/organizations/{1}/inventory'.format(str(base_url), str(orgid))
@@ -2170,7 +2170,7 @@ def getsnmpsettings(apikey, orgid, suppressprint=False, proxies=None, session=No
     # Confirm API Key has Admin Access Otherwise Raise Error
     #
     if verify_access:
-        __hasorgaccess(apikey, orgid)
+        __hasorgaccess(apikey, orgid, proxies=proxies)
     calltype = 'SNMP Settings'
 
     geturl = '{0}/organizations/{1}/snmp'.format(str(base_url), str(orgid))
@@ -2199,7 +2199,7 @@ def updatesnmpsettings(apikey, orgid, v2c=False, v3=False, v3authmode='SHA', v3a
     # Confirm API Key has Admin Access Otherwise Raise Error
     #
     if verify_access:
-        __hasorgaccess(apikey, orgid)
+        __hasorgaccess(apikey, orgid, proxies=proxies)
     calltype = 'SNMP'
     puturl = '{0}/organizations/{1}/snmp'.format(str(base_url), str(orgid))
     headers = {
@@ -2261,7 +2261,7 @@ def getnonmerakivpnpeers(apikey, orgid, suppressprint=False, proxies=None, sessi
     # Confirm API Key has Admin Access Otherwise Raise Error
     #
     if verify_access:
-        __hasorgaccess(apikey, orgid)
+        __hasorgaccess(apikey, orgid, proxies=proxies)
     calltype = 'Non-Meraki VPN'
 
     geturl = '{0}/organizations/{1}/thirdPartyVPNPeers'.format(str(base_url), str(orgid))
@@ -2295,7 +2295,7 @@ def updatenonmerakivpn(apikey, orgid, names, ips, secrets, remotenets, tags=None
     # Confirm API Key has Admin Access Otherwise Raise Error
     #
     if verify_access:
-        __hasorgaccess(apikey, orgid)
+        __hasorgaccess(apikey, orgid, proxies=proxies)
     calltype = 'Non-Meraki VPN'
 
     puturl = '{0}/organizations/{1}/thirdPartyVPNPeers'.format(str(base_url), str(orgid))
@@ -2364,7 +2364,7 @@ def appendnonmerakivpn(apikey, orgid, names, ips, secrets, remotenets, tags=None
     # Confirm API Key has Admin Access Otherwise Raise Error
     #
     if verify_access:
-        __hasorgaccess(apikey, orgid)
+        __hasorgaccess(apikey, orgid, proxies=proxies)
     calltype = 'Non-Meraki VPN'
 
     puturl = '{0}/organizations/{1}/thirdPartyVPNPeers'.format(str(base_url), str(orgid))
@@ -2643,7 +2643,7 @@ def getsamlroles(apikey, orgid, suppressprint=False, proxies=None, session=None,
     # Confirm API Key has Admin Access Otherwise Raise Error
     #
     if verify_access:
-        __hasorgaccess(apikey, orgid)
+        __hasorgaccess(apikey, orgid, proxies=proxies)
     calltype = 'SAML Roles'
 
     geturl = '{0}/organizations/{1}/samlRoles'.format(str(base_url), str(orgid))
@@ -2670,7 +2670,7 @@ def getsamlroledetail(apikey, orgid, roleid, suppressprint=False, proxies=None, 
     # Confirm API Key has Admin Access Otherwise Raise Error
     #
     if verify_access:
-        __hasorgaccess(apikey, orgid)
+        __hasorgaccess(apikey, orgid, proxies=proxies)
     calltype = 'SAML Role Detail'
 
     geturl = '{0}/organizations/{1}/samlRoles/{2}'.format(str(base_url), str(orgid), str(roleid))
@@ -2698,7 +2698,7 @@ def updatesamlrole(apikey, orgid, roleid, rolename, orgaccess, tags, tagaccess, 
     # Confirm API Key has Admin Access Otherwise Raise Error
     #
     if verify_access:
-        __hasorgaccess(apikey, orgid)
+        __hasorgaccess(apikey, orgid, proxies=proxies)
     calltype = 'SAML Role'
 
     puturl = '{0}/organizations/{1}/samlRoles/{2}'.format(str(base_url), str(orgid), str(roleid))
@@ -2796,7 +2796,7 @@ def addsamlrole(apikey, orgid, rolename, orgaccess, tags, tagaccess, networks, n
     # Confirm API Key has Admin Access Otherwise Raise Error
     #
     if verify_access:
-        __hasorgaccess(apikey, orgid)
+        __hasorgaccess(apikey, orgid, proxies=proxies)
     calltype = 'SAML Role'
 
     posturl = '{0}/organizations/{1}/samlRoles'.format(str(base_url), str(orgid))
@@ -2895,7 +2895,7 @@ def delsamlrole(apikey, orgid, roleid, suppressprint=False, proxies=None, sessio
     # Confirm API Key has Admin Access Otherwise Raise Error
     #
     if verify_access:
-        __hasorgaccess(apikey, orgid)
+        __hasorgaccess(apikey, orgid, proxies=proxies)
     calltype = 'SAML Role'
 
     delurl = '{0}/organizations/{1}/samlRoles/{2}'.format(str(base_url), str(orgid), str(roleid))


### PR DESCRIPTION
I have been experiencing with the meraki.py code and it is working fine for a couple of calls but proxy server support was missing and also the possibility of requests.session reuse.

By reusing sessions between calls, I have seen a major improvement in performance.  There is still the limit of 5 concurrent sessions per seconds per organization on the Dashboard so that has to be kept in mind if you want to do multiprocessing with it.  That number of concurrent sessions is calculated with both the API calls as well as the users on the web Dashboard.

We have a network of more than 2000 MS switches (soon 3700) and this does make a major difference, for example, if we want to fetch information throughout the network.